### PR TITLE
Markdown formatting fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 EvoPop Theme
-===========
+============
 
 EvoPop is a modern desktop theme suite. Its design is mostly flat with a minimal use of shadows for depth.
 After a year of absence the theme has been revamped with Paper theme as a base.
@@ -9,11 +9,11 @@ EvoPop has been developed primarily with modern GTK3 (GNOME-based) desktop envir
 
 EvoPop is distributed under the terms the GNU General Public License (GNU GPL v.3).
 
-###Getting EvoPop
+### Getting EvoPop
 
 You can download the EvoPop [here](https://github.com/solus-cold-storage/evopop-gtk-theme).
 
-###Building EvoPop
+### Building EvoPop
 
 You can build and install the EvoPop GTK theme from source:
 
@@ -23,13 +23,13 @@ You can build and install the EvoPop GTK theme from source:
 
 This procedure requires ```autotools``` on your system.
 
-###Installing EvoPop
+### Installing EvoPop
 
 Alternatively you may install EvoPop with the provided installation script:
 
     ./install-gtk-theme.sh
 
-###Geary Fix
+### Geary Fix
 
 For those of you who run Geary, there is a common problem where it uses the active font color for regular buttons. Which makes them unreadable.
 This bash file makes a decent workaround (which is also fine to use for other themes)


### PR DESCRIPTION
You need to add a space after the three hash signs to signify a heading — on GitHub, at least — and I’ve done just that. This is a one-click fix! 👍